### PR TITLE
added dependency for MTurkRequestError

### DIFF
--- a/launch_hits.py
+++ b/launch_hits.py
@@ -2,6 +2,7 @@ import argparse, json
 
 from boto.mturk.price import Price
 from boto.mturk.question import HTMLQuestion
+from boto.mturk.connection import MTurkRequestError
 
 import simpleamt
 


### PR DESCRIPTION
Seems like there's a new dependency that requires this explicit import for the example in `README.md` to work.
