### PR TITLE
added output directory to config file for rendered templates

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+  "rendered_template_directory" : "rendered_templates",
   "template_directories": [ "hit_templates" ],
   "aws_access_key": "XXXXXXXXX",
   "aws_secret_key": "XXXXXXXXX"


### PR DESCRIPTION
Figured it'd be useful to add back in `rendered_template_directory` to the config file in case anybody is trying to render custom templates with `render_template.py` 
