### PR TITLE
add support for multiple locales

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==2.7.3
 MarkupSafe==0.23
-boto==2.34.0
+boto==2.42.0
 wsgiref==0.1.2

--- a/simpleamt.py
+++ b/simpleamt.py
@@ -74,7 +74,7 @@ def setup_qualifications(hit_properties):
   """
   qual = Qualifications()
   if 'country' in hit_properties:
-    qual.add(LocaleRequirement('EqualTo',
+    qual.add(LocaleRequirement('In',
       hit_properties['country']))
     del hit_properties['country']
 


### PR DESCRIPTION
boto version 2.42 supports MTurk's "In" operator for qualifications. This is useful if people want to accept workers from multiple locales.
